### PR TITLE
Add Performance Platform client to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "backbone": "1.1.2",
     "underscore": "1.7.0",
-    "govuk_frontend_toolkit": "3.0.1"
+    "govuk_frontend_toolkit": "3.0.1",
+    "performanceplatform-client.js": "0.0.1"
   }
 }


### PR DESCRIPTION
The app fails to run the browserify task during deployment without the client being present.
