### PR TITLE
Display message if dashboard is unsupported

### DIFF
--- a/src/js/renderer.js
+++ b/src/js/renderer.js
@@ -13,6 +13,14 @@ module.exports = {
     return data.displaySlide ? Mustache.render(this.getTemplate(), data) : '';
   },
 
+  renderErrorSlide: function (dashboard, str) {
+    return Mustache.render(this.getTemplate(), {
+      dashboardTitle: dashboard.title,
+      dashboardSlug: dashboard.slug,
+      contents: '<p class="error-message">' + str + '</p>'
+    });
+  },
+
   getTemplate: function () {
     return fs.readFileSync(__dirname + '/templates/layout.mus', 'utf8');
   },

--- a/src/sass/slide.scss
+++ b/src/sass/slide.scss
@@ -110,4 +110,9 @@
     text-decoration: none;
   }
 
+  .error-message {
+    font-size: 5vw;
+    line-height: 1.2;
+  }
+
 }

--- a/test/js/slides.spec.js
+++ b/test/js/slides.spec.js
@@ -251,5 +251,88 @@ describe('slides', function () {
 
   });
 
+  describe('Dashboard not available slide', function () {
+
+    describe('If not modules then display message', function () {
+
+      beforeEach(function (done) {
+        this.slidesPromise.then(function () {
+          done();
+        });
+        this.deferred.resolve({
+          title: 'FooService',
+          slug: 'foo-service',
+          modules: []
+        });
+      });
+
+      it('error should be there', function () {
+
+        $(this.container).find('.error-message')
+          .should.exist;
+      });
+
+    });
+
+    describe('If no valid modules then display message', function () {
+
+      beforeEach(function (done) {
+        this.slidesPromise.then(function () {
+          done();
+        });
+        this.deferred.resolve({
+          title: 'FooService',
+          slug: 'foo-service',
+          modules: [{
+            slug: 'foo-module',
+            title: 'FooModule',
+            'module-type': 'single_timeseries',
+            data: [
+              { formatted_value: 'no data' },
+              { formatted_value: 'no data' }
+            ]
+          }]
+        });
+      });
+
+      it('error should be there', function () {
+
+        $(this.container).find('.error-message')
+          .should.exist;
+      });
+
+    });
+
+    describe('If valid modules then don\'t display message', function () {
+
+      beforeEach(function (done) {
+        this.slidesPromise.then(function () {
+          done();
+        });
+        this.deferred.resolve({
+          title: 'FooService',
+          slug: 'foo-service',
+          modules: [{
+            slug: 'foo-module',
+            title: 'FooModule',
+            'module-type': 'single_timeseries',
+            data: [
+              { formatted_value: 'foo' },
+              { formatted_value: 'bar' }
+            ]
+          }]
+        });
+      });
+
+      it('error should be there', function () {
+
+        $(this.container).find('.error-message')
+          .should.not.exist;
+      });
+
+    });
+
+  });
+
 });
 


### PR DESCRIPTION
If there are no modules to be displayed for a dashboard at the moment it
will just display a blank gray screen. This will pop up a message saying
that the dashboard is not currently supported.