### PR TITLE
If a dashboard errors show an unavailable message

### DIFF
--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -41,6 +41,12 @@ module.exports = function (dashboardSlug, slideContainer) {
       slideContainer.innerHTML = html;
 
     }, function (err) {
+      slideContainer.classList.add('on-screen');
+      slideContainer.innerHTML = renderer.renderErrorSlide(
+        { title: dashboardSlug,
+          slug: dashboardSlug },
+        'Dashboard not currently available in big screen view');
+
       throw(err);
     });
 

--- a/test/js/slides.spec.js
+++ b/test/js/slides.spec.js
@@ -324,7 +324,7 @@ describe('slides', function () {
         });
       });
 
-      it('error should be there', function () {
+      it('error should not be there', function () {
 
         $(this.container).find('.error-message')
           .should.not.exist;
@@ -332,6 +332,28 @@ describe('slides', function () {
 
     });
 
+    describe('If it errors it displays a message', function () {
+
+      beforeEach(function (done) {
+        this.slidesPromise.then(function () {
+          done();
+        }, function() {
+          done();
+        });
+        this.deferred.reject();
+      });
+
+      it('error should be there', function () {
+
+        $(this.container).find('.error-message')
+          .should.exist;
+      });
+
+      it('should be on screen', function () {
+        $(this.container).should.have.class('on-screen');
+      });
+
+    });
   });
 
 });


### PR DESCRIPTION
The gray screen strikes again when the code errors retrieving the
dashboard configuration. We should replace this with some text, because
text is nicer than errors.

We need to ensure the `on-screen` class is applied otherwise the error
message hides off screen.