### PR TITLE
Fix text overlap on very wide displays

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,22 +46,6 @@ gulp.task('browserify', function () {
     .pipe(gulp.dest('./js/'));
 });
 
-gulp.task('karma', function () {
-  return gulp.src(config.testPath + '/*.spec.js', {read: false})
-    .pipe(karma({
-      configFile: 'test/karma.conf.js',
-      action: 'run'
-    }));
-});
-
-gulp.task('karma-watch', function () {
-  return gulp.src(config.testPath + '/*.spec.js', {read: false})
-    .pipe(karma({
-      configFile: 'test/karma.conf.js',
-      action: 'watch'
-    }));
-});
-
 gulp.task('connect', function () {
   connect.server({
     'fallback': 'index.html',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This project is a JavaScript application for displaying data from the Performance Platform fullscreen on a large display, for example in building receptions and offices.",
   "private": true,
   "scripts": {
-    "test": "gulp test"
+    "test": "./node_modules/karma/bin/karma start test/karma.conf.js --single-run"
   },
   "author": "",
   "repository": {
@@ -33,7 +33,6 @@
     "sinon-chai": "2.6.0",
     "vinyl-source-stream": "1.0.0",
     "karma": "0.12.28",
-    "gulp-karma": "0.0.4",
     "karma-browserify": "1.0.0",
     "karma-mocha": "0.1.3",
     "karma-chai": "0.1.0",

--- a/src/js/data-transform.js
+++ b/src/js/data-transform.js
@@ -23,9 +23,9 @@ module.exports = {
     if (data.displaySlide) {
       data = this.missingDataFlags(data);
       data = this.dataConversions(data);
-    }
-    if (data.latest.formatted_value.length > 5) {
-      data.longValue = true;
+      if (data.latest.formatted_value && data.latest.formatted_value.length > 5) {
+        data.longValue = true;
+      }
     }
     return data;
   },

--- a/src/js/data-transform.js
+++ b/src/js/data-transform.js
@@ -24,6 +24,9 @@ module.exports = {
       data = this.missingDataFlags(data);
       data = this.dataConversions(data);
     }
+    if (data.latest.formatted_value.length > 5) {
+      data.longValue = true;
+    }
     return data;
   },
 

--- a/src/js/templates/layout.mus
+++ b/src/js/templates/layout.mus
@@ -2,7 +2,7 @@
   <div class="content">
     <h2 class="dashboard-title">{{ dashboardTitle }}</h2>
     <h3 class="t-module-title module-title">{{ title }}</h3>
-    <span class="t-main-figure js-main-figure main-figure{{^latestAvailable}} main-figure-no-data{{/latestAvailable}}">{{ latest.formatted_value }}</span>
+    <span class="t-main-figure js-main-figure main-figure{{^latestAvailable}} main-figure-no-data{{/latestAvailable}}{{#longValue}} main-figure-long-value{{/longValue}}">{{ latest.formatted_value }}</span>
     {{{contents}}}
     <p class="data-url"><a class="link-dashboard" href="http://www.gov.uk/performance/{{ dashboardSlug }}#{{ slug }}">www.gov.uk/performance/{{ dashboardSlug }}</a></p>
   </div>

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -18,7 +18,7 @@ body {
   background: $grey-2;
   height: 100%;
   overflow: hidden;
-  font-size: 4.5vmin;
+  @include v-font-size(4.5);
 }
 
 #fs {
@@ -46,7 +46,7 @@ body {
   cursor: pointer;
   padding: 0;
   margin: 0;
-  font-size: 2.75vmin;
+  @include v-font-size(2.75);
   color: $white;
   text-decoration: underline;
 }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -18,6 +18,7 @@ body {
   background: $grey-2;
   height: 100%;
   overflow: hidden;
+  font-size: 4.5vmin;
 }
 
 #fs {
@@ -45,7 +46,7 @@ body {
   cursor: pointer;
   padding: 0;
   margin: 0;
-  font-size: 1.5vw;
+  font-size: 2.75vmin;
   color: $white;
   text-decoration: underline;
 }

--- a/src/sass/slide.scss
+++ b/src/sass/slide.scss
@@ -5,7 +5,6 @@
 .slide {
   background-color: $govuk-blue;
   color: $white;
-  font-size: 2.5vw;
   margin: 0;
   padding: 8%;
   height: 100%;
@@ -44,11 +43,11 @@
 
   .module-title,
   .intro-title {
-    font-size: 5vw;
+    font-size: 8vmin;
   }
 
   .data-from {
-    font-size: 2.5vw;
+    font-size: 4.5vmin;
   }
 
   .content {
@@ -57,20 +56,19 @@
   }
 
   .main-figure {
-    font-size: 18vw;
+    font-size: 30vmin;
     display: block;
-  }
-
-  .main-figure-no-data {
-    font-size: 14vw;
+    &.main-figure-long-value {
+      font-size: 24vmin;
+    }
   }
 
   .year-ending {
-    margin-bottom: 1vw;
+    margin-bottom: 1.7vmin;
   }
 
   .data-url {
-    font-size: 1.8vw;
+    font-size: 3.3vmin;
     font-weight: normal;
     position: absolute;
     bottom: 6%;
@@ -111,7 +109,7 @@
   }
 
   .error-message {
-    font-size: 5vw;
+    font-size: 7.7vmin;
     line-height: 1.2;
   }
 

--- a/src/sass/slide.scss
+++ b/src/sass/slide.scss
@@ -2,6 +2,12 @@
 @import '../../node_modules/govuk_frontend_toolkit/stylesheets/_conditionals';
 @import 'colours';
 
+@mixin v-font-size($size) {
+  font-size: ($size * 5) + px;    /* old */
+  font-size: $size + vm;   /* IE9 */
+  font-size: $size + vmin;
+}
+
 .slide {
   background-color: $govuk-blue;
   color: $white;
@@ -28,7 +34,7 @@
   }
 
   @include media(tablet) {
-    padding-left: 20%;
+    padding-left: 15%;
   }
 
   &.on-screen {
@@ -43,11 +49,11 @@
 
   .module-title,
   .intro-title {
-    font-size: 8vmin;
+    @include v-font-size(6);
   }
 
   .data-from {
-    font-size: 4.5vmin;
+    @include v-font-size(4.5);
   }
 
   .content {
@@ -56,19 +62,19 @@
   }
 
   .main-figure {
-    font-size: 30vmin;
+    @include v-font-size(26);
     display: block;
     &.main-figure-long-value {
-      font-size: 24vmin;
+      @include v-font-size(21);
     }
   }
 
   .year-ending {
-    margin-bottom: 1.7vmin;
+    @include v-font-size(3.3);
   }
 
   .data-url {
-    font-size: 3.3vmin;
+    @include v-font-size(3.3);
     font-weight: normal;
     position: absolute;
     bottom: 6%;
@@ -109,7 +115,7 @@
   }
 
   .error-message {
-    font-size: 7.7vmin;
+    @include v-font-size(7.7);
     line-height: 1.2;
   }
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -24,6 +24,8 @@ module.exports = function (karma) {
     singleRun: false,
     autoWatch: true,
 
+    browserNoActivityTimeout: 20000,
+
     // browserify configuration
     browserify: {
       debug: true,


### PR DESCRIPTION
Use vh font sizes instead of vw to fix text overlap when the aspect ratio of the display is very high

https://www.agileplannerapp.com/boards/15088/cards/9114