### PR TITLE
restore spacing below 'year ending' line

### DIFF
--- a/src/sass/slide.scss
+++ b/src/sass/slide.scss
@@ -71,6 +71,7 @@
 
   .year-ending {
     @include v-font-size(3.3);
+    margin-bottom: 1.7vmin;
   }
 
   .data-url {


### PR DESCRIPTION
eg. visible on https://www.performance.service.gov.uk/big-screen/prison-visits