### PR TITLE
Bugfix/remove support grouped timeseries

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   },
   "dependencies": {
     "backbone": "1.1.2",
-    "underscore": "1.7.0",
     "govuk_frontend_toolkit": "3.0.1",
-    "performanceplatform-client.js": "git+https://github.com/alphagov/performanceplatform-client.js.git#release_132",
-    "mustache": "0.8.2"
+    "lodash": "2.4.1",
+    "mustache": "0.8.2",
+    "performanceplatform-client.js": "git+https://github.com/alphagov/performanceplatform-client.js.git#release_132"
   }
 }

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
   interval: 10 * 60 * 1000,

--- a/src/js/carousel.js
+++ b/src/js/carousel.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 
 module.exports = {
 

--- a/src/js/realtime-update.js
+++ b/src/js/realtime-update.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 var Delta = require('performanceplatform-client.js').Delta;
 
 var RealtimeUpdate = function (dashboard, dashboardConfig, module, slideContainer) {

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -1,4 +1,4 @@
-var _ = require('underscore'),
+var _ = require('lodash'),
   Dashboard = require('performanceplatform-client.js').Dashboard,
   renderer = require('./renderer'),
   dataTransform = require('./data-transform'),

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
   Dashboard = require('performanceplatform-client.js').Dashboard,
+  Module = require('performanceplatform-client.js').Module,
   renderer = require('./renderer'),
   dataTransform = require('./data-transform'),
   RealtimeUpdate = require('./realtime-update');
@@ -12,7 +13,12 @@ module.exports = function (dashboardSlug, slideContainer) {
       var html = '',
         realTimeUpdates = [],
         preparedSlides,
-        slidesToRender;
+        slidesToRender,
+        supported = _.without(Module.prototype.supported, 'grouped_timeseries');
+
+      _.remove(dashboardConfig.modules, function (module) {
+        return _.contains(supported, module.moduleConfig['module-type']) === false;
+      });
 
       preparedSlides = _.map(dashboardConfig.modules, function (module) {
         if (module) {

--- a/src/js/templates/kpi.mus
+++ b/src/js/templates/kpi.mus
@@ -1,6 +1,6 @@
 <div>
-    <p class="year-ending">for the {{ latest.period }} ending {{ latest.formatted_end_at }}</p>
-    {{#showChange}}
-      <p class="t-change change change-{{ latest.formatted_change_from_previous.trend }}">{{ latest.formatted_change_from_previous.change }} from the {{ latest.period }} ending {{ previous.formatted_end_at }}</p>
-    {{/showChange}}
-  </div>
+  <p class="year-ending">for the {{ latest.period }} ending {{ latest.formatted_end_at }}</p>
+  {{#showChange}}
+    <p class="t-change change change-{{ latest.formatted_change_from_previous.trend }}">{{ latest.formatted_change_from_previous.change }} from the {{ latest.period }} ending {{ previous.formatted_end_at }}</p>
+  {{/showChange}}
+</div>

--- a/test/js/slides.spec.js
+++ b/test/js/slides.spec.js
@@ -19,6 +19,9 @@ describe('slides', function () {
   var realtimeConfig = require(
     '../../node_modules/performanceplatform-client.js/test/fixtures/module-config-realtime.json'
   );
+  var groupedTimeseriesConfig = require(
+    '../../node_modules/performanceplatform-client.js/test/fixtures/module-config-grouped-time-series.json'
+  );
 
   dashboardConfig.modules = [];
   dashboardConfig.modules[0] = kpiConfig;
@@ -180,6 +183,28 @@ describe('slides', function () {
     it('shows change since last period', function () {
       $(this.container).find('.t-slide-user_satisfaction_graph .t-change')
         .should.have.text('−0.46% on previous 7 days');
+        $(this.container).find('.t-slide-user_satisfaction_graph .t-change').length.should.equal(1);
+    });
+
+  });
+
+  describe('Grouped timeseries', function () {
+
+    beforeEach(function (done) {
+      this.slidesPromise.then(function () {
+        done();
+      });
+
+      this.dashboardConfig.modules = [];
+      this.dashboardConfig.modules[0] = groupedTimeseriesConfig;
+      this.deferred.resolve(this.dashboardConfig);
+    });
+
+    it('does not render a slide', function () {
+      $(this.container).find('.slide').length
+        .should.equal(1);
+      $(this.container).find('.error-message')
+          .should.exist;
     });
 
   });

--- a/test/js/slides.spec.js
+++ b/test/js/slides.spec.js
@@ -57,7 +57,7 @@ describe('slides', function () {
       });
 
       it('doesn\'t show the slide', function () {
-        expect($(this.container).find('.t-slide-kpi').length).to.equal(0);
+        $(this.container).find('.t-slide-kpi').length.should.equal(0);
       });
 
     });
@@ -101,7 +101,7 @@ describe('slides', function () {
       });
 
       it('doesnt show data value for the second-most-recent period or change %', function () {
-        expect($(this.container).find('.t-second-most-recent').length).to.equal(0);
+        $(this.container).find('.t-second-most-recent').length.should.equal(0);
       });
 
     });
@@ -117,8 +117,8 @@ describe('slides', function () {
       });
 
       it('doesn\'t show data for second most recent period', function () {
-        expect($(this.container).find('.t-slide-kpi').first()
-          .find('.t-second-most-recent,.t-change').length).to.equal(0);
+        $(this.container).find('.t-slide-kpi').first()
+          .find('.t-second-most-recent,.t-change').length.should.equal(0);
       });
 
     });
@@ -135,7 +135,7 @@ describe('slides', function () {
       });
 
       it('doesn\'t show the slide', function () {
-        expect($(this.container).find('.t-slide-kpi').length).to.equal(0);
+        $(this.container).find('.t-slide-kpi').length.should.equal(0);
       });
 
     });


### PR DESCRIPTION
The new client supportes grouped_timeseries data.

The big screen view doesn't. Remove support for rendering this slide.