### PR TITLE
Analytics

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,8 @@
     "afterEach"  : false,
     "sinon"      : false,
     "document"   : false,
-    "window"     : false
+    "window"     : false,
+    "GOVUK"      : true
   },
 
   /* Enforcing options */

--- a/index.html
+++ b/index.html
@@ -5,15 +5,6 @@
     <meta charset="utf-8">
     <title>Performance Platform display view</title>
     <link rel="stylesheet" type="text/css" href="css/app.css" />
-    <script type="text/javascript">
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-26179049-9', 'auto');
-      ga('send', 'pageview');
-    </script>
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "backbone": "1.1.2",
-    "govuk_frontend_toolkit": "3.0.1",
+    "govuk_frontend_toolkit": "3.2.0",
     "lodash": "2.4.1",
     "mustache": "0.8.2",
     "performanceplatform-client.js": "git+https://github.com/alphagov/performanceplatform-client.js.git#release_142"

--- a/src/js/analytics-init.js
+++ b/src/js/analytics-init.js
@@ -1,0 +1,25 @@
+(function () {
+  'use strict';
+
+  // Load Google Analytics libraries
+  GOVUK.Tracker.load();
+
+  // Use document.domain in dev, preview and staging so that tracking works
+  // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
+  var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
+
+  // Configure profiles, setup custom vars, track initial pageview
+  GOVUK.analytics = new GOVUK.Tracker({
+    universalId: 'UA-XXXXXXX-X',
+    classicId: 'UA-26179049-9',
+    cookieDomain: cookieDomain
+  });
+
+  // Set custom dimensions before tracking pageviews
+  if (window.devicePixelRatio) {
+    GOVUK.analytics.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
+  }
+
+  // Track initial pageview
+  GOVUK.analytics.trackPageview();
+})();

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -15,13 +15,10 @@ module.exports = {
 
     currentTime = this.getCurrentTime();
     elapsedMinutes = Math.round(((currentTime - this.startTime) / 1000) / 60);
-    window.ga('send', {
-      'hitType': 'event',
-      'eventCategory': window.location.pathname,
-      'eventAction': 'minutes-since-page-load',
-      'eventLabel': '',
-      'eventValue': elapsedMinutes,
-      'nonInteraction': true
+
+    GOVUK.analytics.trackEvent(window.location.pathname, 'minutes-since-page-load', {
+      value: elapsedMinutes,
+      nonInteraction: true // event will not affect bounce rate
     });
   }
 };

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,6 +9,10 @@ require('./slides')(dashboardSlug, container).then(function () {
 var fullscreen = require('./fullscreen')(container);
 document.getElementById('full-screen-toggle').onclick = fullscreen;
 
+require('govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-classic-tracker');
+require('govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker');
+require('govuk_frontend_toolkit/javascripts/govuk/analytics/tracker');
+require('./analytics-init');
 var analytics = require('./analytics');
 analytics.setup();
 

--- a/test/js/analytics.spec.js
+++ b/test/js/analytics.spec.js
@@ -3,17 +3,22 @@ describe('analytics', function () {
   beforeEach(function () {
     var analytics;
     this.clock = sinon.useFakeTimers();
-    window.ga = function () { };
-    this.spy = sinon.spy(window, 'ga');
+    window.GOVUK = {
+      analytics: {
+        trackEvent: function() {}
+      }
+    };
+    this.spy = sinon.spy(window.GOVUK.analytics, 'trackEvent');
     analytics = require('../../src/js/analytics');
     analytics.setup();
     this.clock.tick(analytics.interval + 500);
   });
 
   it('should send the elapsed time and action with the GA event', function () {
-    var event = this.spy.args[0][1];
+    console.log(this.spy.args[0]);
+    var callArgs = this.spy.args[0];
     this.spy.calledOnce.should.equal(true);
-    event.eventValue.should.equal(10);
-    event.eventAction = 'minutes-since-page-load';
+    callArgs[2].value.should.equal(10);
+    callArgs[1].should.equal('minutes-since-page-load');
   });
 });


### PR DESCRIPTION
From [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md)

The new library sends data just to the GA classic account for big screen. There isn't a universal account so it uses a dummy account ID for that, because the analytics library doesn't have an option to use just classic or universal, it uses both by default.