### PR TITLE
Disable rendering of grouped_timeseries that have group_mappings

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,7 +4,10 @@ var dashboardSlug = window.location.pathname.split('/').pop();
 
 require('./slides').setup(dashboardSlug, container).then(function () {
   require('./carousel').setup(document);
-});
+}).catch(function (error) {
+  throw error;
+})
+.done();
 
 var fullscreen = require('./fullscreen')(container);
 document.getElementById('full-screen-toggle').onclick = fullscreen;

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -50,7 +50,6 @@ module.exports = {
         }
 
         slideContainer.innerHTML = html;
-
       }, this), function (err) {
         slideContainer.classList.add('on-screen');
         slideContainer.innerHTML = renderer.renderErrorSlide(
@@ -83,14 +82,17 @@ module.exports = {
           flattenedModules.push(nestedModule);
         });
       } else {
+        // we can't currently support grouped-timeseries with a group mapping this should be done
+        // in the transform
+        if (module.moduleConfig['group-mapping']) {
+          return;
+        }
         module.dataAsDelta = new Delta(module);
-
         if (_.isArray(module.dataAsDelta.data) === false) {
-          _.each(module.dataAsDelta.data, function (series, key) {
+          _.each(module.axes.y, function (yAxis) {
             var seriesData = _.cloneDeep(module);
-            seriesData.moduleConfig.title += ': ' +
-              _.pluck(_.where(module.axes.y, {'groupId': key}), 'label');
-            seriesData.dataAsDelta.data = series;
+            seriesData.moduleConfig.title += ': ' + yAxis.label;
+            seriesData.dataAsDelta.data = seriesData.dataAsDelta.data[yAxis.groupId];
             flattenedModules.push(seriesData);
           });
         }

--- a/test/js/slides.spec.js
+++ b/test/js/slides.spec.js
@@ -391,17 +391,12 @@ describe('slides', function () {
 
     it('shows the most recent figure, if available', function () {
       $(this.container).find('.t-slide-grouped_timeseries:first .t-main-figure')
-        .should.have.text('13033');
-    });
-
-    it('shows the most recent figure, if available', function () {
-      $(this.container).find('.t-slide-grouped_timeseries:first .t-main-figure')
-        .should.have.text('13033');
+        .should.have.text('2629544');
     });
 
     it('shows change since last period', function () {
       $(this.container).find('.t-slide-grouped_timeseries:first .t-change')
-        .should.have.text('−5.01% on previous a month');
+        .should.have.text('+21.90% on previous a month');
     });
 
   });


### PR DESCRIPTION
Modules that use group_mappings should do so in the transform not at the front end.

Ensure when we get an error we throw it so we can see what's happing (don't let it get consumed in the promise)

Don't render all entries in the data object (render the data via the axes).