### PR TITLE
Bump client version (grouped totals fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "govuk_frontend_toolkit": "3.2.0",
     "lodash": "2.4.1",
     "mustache": "0.8.2",
-    "performanceplatform-client.js": "git+https://github.com/alphagov/performanceplatform-client.js.git#release_157"
+    "performanceplatform-client.js": "git+https://github.com/alphagov/performanceplatform-client.js.git#release_169"
   }
 }


### PR DESCRIPTION
Incorporating this client change - https://github.com/alphagov/performanceplatform-client.js/pull/53

If there's a show-total-lines create a new grouping in the data.