### PR TITLE
Fix broken Big Screen View on IE9

### DIFF
--- a/src/js/carousel.js
+++ b/src/js/carousel.js
@@ -6,7 +6,7 @@ module.exports = {
     var interval;
     this.container = container;
     this.currentSlideIndex = 0;
-    this.container.querySelector('.slide').classList.add('on-screen');
+    this.container.querySelector('.slide').className += " on-screen";
     if (this.container.querySelectorAll('.slide').length > 1) {
       try {
         interval = parseInt(this.getQueryStringValueByKey('interval'), 10) * 1000;
@@ -21,10 +21,10 @@ module.exports = {
     var slides = this.container.getElementsByClassName('slide'),
       previous = slides[this.currentSlideIndex];
 
-    previous.classList.add('previously-on-screen');
-    previous.classList.remove('on-screen');
+    previous.className += " previously-on-screen";
+    previous.className = previous.className.replace(" on-screen", "");
     previous.addEventListener('transitionend', function () {
-      previous.classList.remove('previously-on-screen');
+      previous.className = previous.className.replace(" previously-on-screen", "");
     }, false);
 
     this.currentSlideIndex += 1;
@@ -32,7 +32,7 @@ module.exports = {
       this.currentSlideIndex = 0;
     }
 
-    slides[this.currentSlideIndex].classList.add('on-screen');
+    slides[this.currentSlideIndex].className += " on-screen";
   },
 
   getQueryStringValueByKey: function (key) {

--- a/src/js/cursor.js
+++ b/src/js/cursor.js
@@ -5,13 +5,13 @@ module.exports = function (container) {
   setTimer = function () {
     clearTimeout(timer);
     timer = setTimeout(function () {
-      container.classList.add('is-inactive');
+      container.className += " is-inactive";
     }, 5000);
   };
 
   setTimer();
   container.addEventListener && container.addEventListener('mousemove', function () {
-    container.classList.remove('is-inactive');
+    container.className = container.className.replace(" is-inactive", "");
     setTimer();
   });
 

--- a/src/js/slides.js
+++ b/src/js/slides.js
@@ -68,7 +68,7 @@ module.exports = {
 
         slideContainer.innerHTML = html;
       }, this), function (err) {
-        slideContainer.classList.add('on-screen');
+        slideContainer.className += " on-screen";
         slideContainer.innerHTML = renderer.renderErrorSlide(
           {
             title: dashboardSlug,


### PR DESCRIPTION
The classList.add | remove not supported in IE9 so replace with use of className.

Story: https://www.pivotaltracker.com/story/show/108455442